### PR TITLE
fix install tarpaulin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-01-01
+          toolchain: nightly-2024-05-01
           components: rustfmt, clippy
 
       - name: Check formatting
@@ -60,11 +60,11 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly
+          toolchain: nightly-2024-05-01
           components: rustfmt, clippy
 
       - name: Install Tarpaulin
-        run: cargo install cargo-tarpaulin --locked
+        run: cargo install cargo-tarpaulin --version 0.31.0 --locked
 
       # Tarpaulinの出力を tee でファイルにも保存
       - name: Run Tarpaulin

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -89,6 +89,14 @@ tasks:
         docker compose exec -T os-dev cargo test
         --workspace
 
+  test:coverage:
+    desc: Run tests with coverage report using cargo-tarpaulin
+    cmds:
+      - >-
+        docker compose exec -T os-dev cargo install cargo-tarpaulin --locked
+      - >-
+        docker compose exec -T os-dev cargo tarpaulin --workspace
+
   before-commit:
     cmds:
       - task lint

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2024-01-01"
+channel = "nightly-2024-05-01"
 components = ["rustfmt", "rust-src"]
 targets = ["x86_64-unknown-linux-gnu"]
 profile = "default"


### PR DESCRIPTION
This pull request updates the Rust toolchain version across the project, adds support for running test coverage with `cargo-tarpaulin`, and introduces a new task for generating coverage reports. Below are the most important changes grouped by theme:

### Rust Toolchain Updates:
* Updated the Rust toolchain version from `nightly-2024-01-01` to `nightly-2024-05-01` in `.github/workflows/ci.yml` and `rust-toolchain.toml` for consistency across the project. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL41-R41) [[2]](diffhunk://#diff-2b1bde2cf3a858b7bf7424cb8bcbf01f35b94dc80b925d9432cbab3319ca9b4eL2-R2)

### Test Coverage Enhancements:
* Modified the CI workflow to install `cargo-tarpaulin` with an additional `RUSTFLAGS` configuration for better dependency handling.
* Added a new `test:coverage` task in `Taskfile.yml` to run tests with coverage reporting using `cargo-tarpaulin`.
This pull request updates the Rust toolchain version used across the project, improves test coverage reporting, and introduces a new Taskfile task for running tests with coverage. Below are the most important changes:

### Rust Toolchain Updates:
* Updated the Rust toolchain version from `nightly-2024-01-01` to `nightly-2024-05-01` in `.github/workflows/ci.yml` and `rust-toolchain.toml` for consistency across the project. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL41-R41) [[2]](diffhunk://#diff-2b1bde2cf3a858b7bf7424cb8bcbf01f35b94dc80b925d9432cbab3319ca9b4eL2-R2)

### Test Coverage Enhancements:
* Updated the `cargo-tarpaulin` installation command in `.github/workflows/ci.yml` to specify version `0.31.0` for better reproducibility.

### Taskfile Improvements:
* Added a new `test:coverage` task in `Taskfile.yml` to run tests with a coverage report using `cargo-tarpaulin`. This includes installing `cargo-tarpaulin` and running it within the Docker environment.