### PR TITLE
feat(task): add clippy task for UEFI target

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -53,7 +53,15 @@ tasks:
   lint:rust:
     cmds:
       - cargo fmt --all -- --check
-      - cargo clippy --workspace -- -D warnings
+      - task: clippy
+
+  clippy:
+    desc: Run cargo clippy
+    cmds:
+      - >-
+        cargo +nightly clippy --target x86_64-unknown-uefi
+        -Zbuild-std=core,compiler_builtins,alloc,panic_abort
+        -Zbuild-std-features=compiler-builtins-mem -- -D warnings
 
   # ---------------------------
   # format
@@ -70,7 +78,7 @@ tasks:
   format:rust:
     cmds:
       - cargo fmt --all
-      - cargo clippy --workspace -- -D warnings
+      - task: clippy
 
   # ---------------------------
   # Test


### PR DESCRIPTION
- Add dedicated clippy task with UEFI target configuration
- Update lint:rust and format:rust to use the new clippy task
- Include necessary build-std flags for x86_64-unknown-uefi target