### PR TITLE
main.rs の不要コメント削除と軽微なクリーンアップ（機能影響なし）

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -28,8 +28,6 @@ const EFI_GRAPHICS_OUTPUT_PROTOCOL_GUID: EfiGuid = EfiGuid {
     data3: [0x96, 0xfb, 0x7a, 0xde, 0xd0, 0x80, 0x51, 0x6a],
 };
 
-// These directives are experimental and intended for a future transition to a no_std/no_main environment.
-
 #[no_mangle]
 fn efi_main(_image_handle: EfiHandle, efi_system_table: &EfiSystemTable) {
     let mut vram = init_vram(efi_system_table).expect("init_vram failed");
@@ -72,7 +70,6 @@ fn efi_main(_image_handle: EfiHandle, efi_system_table: &EfiSystemTable) {
     for i in (0..vh).step_by(step as usize) {
         let _ = draw_line(&mut vram, 0xff00ff, cx, cy, 0, i);
     }
-    // 右辺への放射線
     for i in (0..vh).step_by(step as usize) {
         let _ = draw_line(&mut vram, 0xffffff, cx, cy, vw - 1, i);
     }


### PR DESCRIPTION
【タイトル】main.rs の不要コメント削除と軽微なクリーンアップ（機能影響なし）

【概要】
UEFIエントリ関数付近の不要な説明コメントを削除し、コードを簡潔化しました。挙動に関する変更はありません。

【差分】
- **ファイル:** [[src/main.rs](url://48)](url://48)（+0 / −3）  
  - 「no_std/no_main への将来移行を想定した実験的ディレクティブ」説明コメントを削除  
  - 余分な空行の整理

【目的】
読みやすさの向上と、現状と合致しないコメントの排除により保守性を高める。

【影響範囲】
- なし（ロジック・バイナリ変更なし）  
- 既存の描画処理・起動フローに影響なし

【確認項目】
- ビルド成功（従来通り）  
- 実機/エミュレータでの起動挙動に差異がないこと

【メタ情報】
- マージ可能（Auto-merge 可）  
- コミットは **Verified**（[[942df7f](url://44)](url://44)）

【関連リンク】
- 差分表示: [[View file](url://49)](url://49)

【ラベル提案】
- **refactor**, **chore**, **documentation**