### PR TITLE
lookup_fontの導入とフォント描画修正（コンパイルエラーの解消）

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -117,28 +117,31 @@ fn efi_main(_image_handle: EfiHandle, efi_system_table: &EfiSystemTable) {
 }
 
 fn draw_font_fg<T: Bitmap>(buf: &mut T, x: i64, y: i64, color: u32, c: char) {
-    if let Ok(_c) = u8::try_from(c) {
-        let font_a = "
-........
-...**...
-...**...
-...**...
-...**...
-..*..*..
-..*..*..
-..*..*..
-..*..*..
-.******.
-.*....*.
-.*....*.
-.*....*.
-***..***
-........
-........
-";
+    //     if let Ok(_c) = u8::try_from(c) {
+    //         let font_a = "
+    // ........
+    // ...**...
+    // ...**...
+    // ...**...
+    // ...**...
+    // ..*..*..
+    // ..*..*..
+    // ..*..*..
+    // ..*..*..
+    // .******.
+    // .*....*.
+    // .*....*.
+    // .*....*.
+    // ***..***
+    // ........
+    // ........
+    // ";
 
-        for (dy, row) in font_a.trim().split('\n').enumerate() {
-            for (dx, pixel) in row.chars().enumerate() {
+    //         for (dy, row) in font_a.trim().split('\n').enumerate() {
+    //             for (dx, pixel) in row.chars().enumerate() {
+    if let Some(font) = lookup_font(c) {
+        for (dy, row) in font.iter().enumerate() {
+            for (dx, pixel) in row.iter().enumerate() {
                 let color = match pixel {
                     '*' => color,
                     _ => continue,
@@ -365,6 +368,32 @@ fn fill_rect<T: Bitmap>(buf: &mut T, color: u32, px: i64, py: i64, w: i64, h: i6
         }
     }
     Ok(())
+}
+
+fn lookup_font(c: char) -> Option<[[char; 8]; 16]> {
+    const FONT_SOURCE: &str = include_str!("font.txt");
+    if let Ok(idx) = u8::try_from(c) {
+        let mut fi = FONT_SOURCE.split('\n');
+        while let Some(line) = fi.next() {
+            if let Some(line) = line.strip_prefix("0x") {
+                if let Ok(c) = u8::from_str_radix(line, 16) {
+                    if idx != c {
+                        continue;
+                    }
+                    let mut font = [['*'; 8]; 16];
+                    for (y, line) in fi.clone().take(16).enumerate() {
+                        for (x, e) in line.chars().enumerate() {
+                            if let Some(c) = font[y].get_mut(x) {
+                                *c = e;
+                            }
+                        }
+                    }
+                    return Some(font);
+                }
+            }
+        }
+    }
+    None
 }
 // テストモジュールを追加
 #[cfg(test)]


### PR DESCRIPTION
【タイトル】lookup_fontの導入とフォント描画修正（コンパイルエラーの解消）

【概要】
8×16ビットマップフォントを外部定義から読み込む **lookup_font** を追加し、文字描画ルーチンをそれに対応する形へ修正しました。併せてコンパイルエラーの原因となっていた変数名・タイポ・不要な括弧を整理しています。

【主な変更点】
- **コード:** [[src/main.rs](url://66)](url://66)（+51 / −22）
  - `lookup_font(c: char) -> Option<[[char; 8]; 16]>` を追加し、`include_str!("font.txt")` から対象文字の16行×8列パターンを取得
  - `draw_font_fg` をフォント配列を用いた描画に変更（`row.iter()`/`pixel.match` 経由で色決定）
  - 変数名修正：`FONT_COURCE → FONT_SOURCE`、`c → idx`、`c → e`（重複・混同の解消）
  - タイポ修正：`enumrate → enumerate`
  - 余分な閉じ括弧、試験用インラインフォント文字列のコメントアウト
- **メタ:** コミットは **Co-Authored-By** を含む更新（[[f8d4a7d](url://62)](url://62)）

【目的】
- フォント定義の外部化による保守性向上と拡張容易化
- 描画処理の安定化およびコンパイルエラーの解消

【影響範囲】
- 文字描画は外部フォント定義（`font.txt`）に依存するようになります
- 既存のライン描画やVRAM初期化への影響はありません

【確認項目】
1. ビルドが成功すること（型・変数名の整合性）  
2. UEFI起動後、指定座標で文字が正しく描画されること  
3. `font.txt` に定義された文字が期待通りに `lookup_font` で取得できること

【関連ファイル・差分】
- 差分: [[src/main.rs](url://66)](url://66) / [[表示](url://67)](url://67)

【ラベル提案】
- **enhancement**, **bug**, **refactor**, **documentation**